### PR TITLE
Add db_root_password var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
         db_name: ${DB_NAME}
         db_user: ${DB_USER}
         db_password: ${DB_PASSWORD}
+        db_root_password: ${DB_ROOT_PASSWORD}
         db_port: ${DB_PORT}
     restart: always
     volumes:


### PR DESCRIPTION
For mysql this entry is missing in docker-compose.yml
`db_root_password: ${DB_ROOT_PASSWORD}'
so that Dockerfile-mysql is populated.